### PR TITLE
Adding asynchronous scraping requests with concurrent.futures

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ pypagerest won't work with versions of Python lower than Python 3.4
 
 ## Installation
 
-The package isn't on PyPI yet but you can install pypagerest using `pipev` (for a relatively straightforward virtual environments setup) or alternatively with `pip3`. This will install the live code from Github. This code is not yet stable (though it's getting there!)
+The package isn't on PyPI yet but you can install pypagerest using `pipev` (for a relatively straightforward virtual environments setup) or alternatively with `pip`/`pip3`. This will install the live code from Github. This code is not yet stable (though it's getting there!)
 
 ```python
 pipenv install -e git+https://github.com/edjw/pypagerest#egg=pypagerest
 ```
 
 ```python
+pip install git+https://github.com/edjw/pypagerest
 pip3 install git+https://github.com/edjw/pypagerest
 ```
 
@@ -28,7 +29,7 @@ pip3 install git+https://github.com/edjw/pypagerest
 
 ### Setup
 
-You have to set some variables which pypagerest will use to retrieve the data you want.
+You have to set some variables in your file that imports pypagerest. Pypagerest will use these variables retrieve the data you want.
 
 ```python
 import pypagerest
@@ -47,13 +48,15 @@ urls = ["https://domain.tld"] # One URL
 urls = ["https://domain.tld", "https://anotherdomain.tld"] # More than one URL
 
 # If you want to extract content using CSS selectors, put the selectors inside square brackets like this
-selectors = [".class_one", ".class_two", "#id_one", "#id_two", "h2", "p"]
+selectors = [".class_one", ".class_two", "#id_one", "#id_two", "h1", "p"]
 
 # If you want to extract HTTP response headers, put the response headers inside square brackets like this
 headers = ["X-Frame-Options", "X-XSS-Protection", "Content-Security-Policy"]
 ```
 
 ### pypagerest functions
+
+Then call whichever of these functions you want to correspond with the functionality described on <https://page.rest>
 
 #### Basic
 
@@ -102,10 +105,6 @@ Get the OpenGraph content for the page as part of the response (only if availabl
 ```python
 pypagerest.get_pr_responseheaders(pr_token, urls, headers)
 ```
-
-<!-- ## Scraping multiple pieces of data
-
-If you want to scrape the CSS selectors and oEmbed/OpenGraph/Response Header content at the same time, then use the `get_pr_selector` function. TODO! -->
 
 ## Output
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ This wrapper makes it easier to access Page.REST using Python. It also make it e
 
 You'll need to buy an [access token for Page.REST](https://page.rest/#payment-block). Tokens cost $5 and are valid for 365 days. There's a daily cap of 100,000 requests per token.
 
-pypagerest won't work with versions of Python lower than Python 3.4
+Pypagerest won't work with versions of Python lower than Python 3.4.
 
 ## Installation
 
-The package isn't on PyPI yet but you can install pypagerest using `pipev` (for a relatively straightforward virtual environments setup) or alternatively with `pip`/`pip3`. This will install the live code from Github. This code is not yet stable (though it's getting there!)
+The package isn't on PyPI yet. You can install the live pypagerest code from Github using `pipev` (for a relatively straightforward virtual environments setup) or alternatively with `pip`/`pip3`.
 
 ```python
 pipenv install -e git+https://github.com/edjw/pypagerest#egg=pypagerest
@@ -29,7 +29,7 @@ pip3 install git+https://github.com/edjw/pypagerest
 
 ### Setup
 
-You have to set some variables in your file that imports pypagerest. Pypagerest will use these variables retrieve the data you want.
+You have to set some variables in your file that imports pypagerest. Pypagerest will use these variables to retrieve the data you want.
 
 ```python
 import pypagerest

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This wrapper makes it easier to access Page.REST using Python. It also make it e
 
 You'll need to buy an [access token for Page.REST](https://page.rest/#payment-block). Tokens cost $5 and are valid for 365 days. There's a daily cap of 100,000 requests per token.
 
+pypagerest won't work with versions of Python lower than Python 3.4
+
 ## Installation
 
 The package isn't on PyPI yet but you can install pypagerest using `pipev` (for a relatively straightforward virtual environments setup) or alternatively with `pip3`. This will install the live code from Github. This code is not yet stable (though it's getting there!)
@@ -109,7 +111,7 @@ If you want to scrape the CSS selectors and oEmbed/OpenGraph/Response Header con
 
 If you request multiple URLs, the output is a Python list of the JSON responses from Page.REST.
 
- If you request only a single URL, the output is the JSON response from Page.REST not in a list. Let me know if you can think of a more useful way of returning the data for real-world use.
+If you request only a single URL, the output is the JSON response from Page.REST not in a list. Let me know if you can think of a more useful way of returning the data for real-world use.
 
 ## Notes
 
@@ -126,12 +128,3 @@ I am new to Python and would appreciate any suggestions of how to improve pypage
 1. Commit your changes `git commit -am 'Add some feature'`
 1. Push to the branch `git push origin my-new-feature`
 1. Create a new Pull Request
-
-## To-Do
-
-* Document how to do one function only on one set of urls, selectors, headers
-* Document how to do more than one function on one set of urls, selectors, headers
-* Document how to do more than one function on more than one set of urls, selectors, headers
-* Document multiple urls with different selectors for each one
-* Annotate pypagerest
-* Enable oEmbed/OpenGraph/Response header content to be requested in selector function

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
 from setuptools import setup
+from sys import version_info
+
+if version_info < (3, 4):
+    raise RuntimeError("This package requres Python 3.4+")
 
 setup(
     name='pypagerest',
@@ -16,7 +20,6 @@ setup(
     zip_safe=False
 )
 
-# # from sys import version_info
 
 # try:
 #     from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from sys import version_info
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,42 @@
-# from sys import version_info
-
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
-
-# if version_info < (3, 4):
-#     raise RuntimeError("This package requres Python 3.4+")
+from setuptools import setup
 
 setup(
     name='pypagerest',
     description='A Python wrapper for Page.REST',
     long_description='A Python wrapper for Page.REST – an HTTP API you can use to extract content from any web page as JSON',
-    keywords='Page.REST scraping api Python wrapper async asynchronous',
+    keywords='Page.REST scraping api Python wrapper',
     url='https://github.com/edjw/pypagerest',
     author='Ed Johnson-Williams',
     author_email='edjohnsonwilliams@gmail.com',
     version='0.2',
     license='MIT',
     packages=['pypagerest'],
-    zip_safe=False,
-    python_requires=['>=3.4'],
-    install_requires=['requests>=2.17.0']
+    install_requires=['requests>2.18.0'],
+    zip_safe=False
 )
+
+# # from sys import version_info
+
+# try:
+#     from setuptools import setup
+# except ImportError:
+#     from distutils.core import setup
+
+# # if version_info < (3, 4):
+# #     raise RuntimeError("This package requres Python 3.4+")
+
+# setup(
+#     name='pypagerest',
+#     description='A Python wrapper for Page.REST',
+#     long_description='A Python wrapper for Page.REST – an HTTP API you can use to extract content from any web page as JSON',
+#     keywords='Page.REST scraping api Python wrapper async asynchronous',
+#     url='https://github.com/edjw/pypagerest',
+#     author='Ed Johnson-Williams',
+#     author_email='edjohnsonwilliams@gmail.com',
+#     version='0.2',
+#     license='MIT',
+#     packages=['pypagerest'],
+#     zip_safe=False,
+#     python_requires=['>=3.4'],
+#     install_requires=['requests>=2.17.0']
+# )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version='0.2',
     license='MIT',
     packages=['pypagerest'],
-    python_requires=['>=3.4'],
+    python_requires='~=3.4',
     install_requires=['requests>2.18.0'],
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     version='0.2',
     license='MIT',
     packages=['pypagerest'],
+    python_requires=['>=3.4'],
     install_requires=['requests>2.18.0'],
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,4 @@ setup(
     zip_safe=False,
     python_requires=['>=3.4'],
     install_requires=['requests>=2.17.0']
-    )
+)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
+from sys import version_info
 from setuptools import setup
+
+if version_info < (3, 4):
+    raise RuntimeError("This package requres Python 3.4+")
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = '\n' + readme.read()
@@ -11,9 +15,10 @@ setup(
     url='https://github.com/edjw/pypagerest',
     author='Ed Johnson-Williams',
     author_email='edjohnsonwilliams@gmail.com',
-    version='0.1',
+    version='0.2',
     license='MIT',
     packages=['pypagerest'],
-    install_requires=['requests'],
+    python_requires=['>=3.4'],
+    install_requires=['requests>2.18'],
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-from setuptools import setup
 from sys import version_info
+from setuptools import setup
 
 if version_info < (3, 4):
     raise RuntimeError("This package requres Python 3.4+")

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     license='MIT',
     packages=['pypagerest'],
     python_requires=['>=3.4'],
-    install_requires=['requests>2.18'],
+    install_requires=['requests>2.18.0'],
     zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     version='0.2',
     license='MIT',
     packages=['pypagerest'],
+    zip_safe=False,
     python_requires=['>=3.4'],
-    install_requires=['requests>=2.17.0'],
-    zip_safe=False
+    install_requires=['requests>=2.17.0']
     )

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,4 @@ setup(
     packages=['pypagerest'],
     python_requires=['>=3.4'],
     install_requires=['requests>2.18'],
-    zip_safe=False
-)
+    zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,18 @@
-#!/usr/bin/env python
+# from sys import version_info
 
-from sys import version_info
-from setuptools import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
-if version_info < (3, 4):
-    raise RuntimeError("This package requres Python 3.4+")
-
-with open('README.md', 'r', encoding='utf-8') as readme:
-    long_description = '\n' + readme.read()
+# if version_info < (3, 4):
+#     raise RuntimeError("This package requres Python 3.4+")
 
 setup(
     name='pypagerest',
     description='A Python wrapper for Page.REST',
-    long_description=long_description,
-    keywords='Page.REST scraping api Python wrapper',
+    long_description='A Python wrapper for Page.REST – an HTTP API you can use to extract content from any web page as JSON',
+    keywords='Page.REST scraping api Python wrapper async asynchronous',
     url='https://github.com/edjw/pypagerest',
     author='Ed Johnson-Williams',
     author_email='edjohnsonwilliams@gmail.com',
@@ -21,5 +20,6 @@ setup(
     license='MIT',
     packages=['pypagerest'],
     python_requires=['>=3.4'],
-    install_requires=['requests>2.18.0']
+    install_requires=['requests>=2.17.0'],
+    zip_safe=False
     )

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     license='MIT',
     packages=['pypagerest'],
     python_requires=['>=3.4'],
-    install_requires=['requests>2.18.0'],
-    zip_safe=False)
+    install_requires=['requests>2.18.0']
+    )


### PR DESCRIPTION
Asynchronous requests means that multiple requests can be made at the same time to Page.REST which significantly speeds up getting data about larger numbers of URLs.

This does mean that the Python version has to be higher than 3.2 which is when concurrent.futures was introduced. For Python 3, Requests seems to only support higher than 3.4 so I've made the minimum version number 3.4 and added a RuntimeError to setup.py which is triggered if the user tries to install on a lower Python version